### PR TITLE
detect connection pool on run

### DIFF
--- a/lib/backfiller/configuration.rb
+++ b/lib/backfiller/configuration.rb
@@ -9,8 +9,6 @@ module Backfiller
 
     attr_accessor :task_namespace
 
-    attr_accessor :connection_pool
-
     attr_accessor :batch_size
 
     attr_accessor :logger

--- a/lib/backfiller/railtie.rb
+++ b/lib/backfiller/railtie.rb
@@ -13,8 +13,6 @@ module Backfiller
 
         config.batch_size = 1_000
 
-        config.connection_pool = defined?(ApplicationRecord) ? ApplicationRecord.connection_pool : ActiveRecord::Base.connection_pool
-
         config.logger = defined?(ApplicationRecord) ? ApplicationRecord.logger : ActiveRecord::Base.logger
       end
     end

--- a/lib/backfiller/runner.rb
+++ b/lib/backfiller/runner.rb
@@ -9,7 +9,7 @@ module Backfiller
 
     def initialize(task_name)
       @task = build_task(task_name)
-      @connection_pool = @task.respond_to?(:connection_pool) ? @task.connection_pool : connection_pool
+      @connection_pool = @task.respond_to?(:connection_pool) ? @task.connection_pool : default_connection_pool
       @batch_size = @task.respond_to?(:batch_size) ? @task.batch_size : Backfiller.batch_size
       @process_method = @task.respond_to?(:process_row) ? @task.method(:process_row) : self.method(:process_row)
     end
@@ -28,10 +28,6 @@ module Backfiller
 
     private
 
-    def connection_pool
-      defined?(ApplicationRecord) ? ApplicationRecord.connection_pool : ActiveRecord::Base.connection_pool
-    end
-
     def build_task(task_name)
       Backfiller.log "Build #{task_name} task"
       require File.join(Backfiller.task_directory, task_name)
@@ -39,6 +35,10 @@ module Backfiller
     end
 
     ###########################################################################
+
+    def default_connection_pool
+      defined?(ApplicationRecord) ? ApplicationRecord.connection_pool : ActiveRecord::Base.connection_pool
+    end
 
     def acquire_connection
       connection_pool.checkout

--- a/lib/backfiller/runner.rb
+++ b/lib/backfiller/runner.rb
@@ -9,7 +9,7 @@ module Backfiller
 
     def initialize(task_name)
       @task = build_task(task_name)
-      @connection_pool = @task.respond_to?(:connection_pool) ? @task.connection_pool : Backfiller.connection_pool
+      @connection_pool = @task.respond_to?(:connection_pool) ? @task.connection_pool : connection_pool
       @batch_size = @task.respond_to?(:batch_size) ? @task.batch_size : Backfiller.batch_size
       @process_method = @task.respond_to?(:process_row) ? @task.method(:process_row) : self.method(:process_row)
     end
@@ -27,6 +27,10 @@ module Backfiller
     end
 
     private
+
+    def connection_pool
+      defined?(ApplicationRecord) ? ApplicationRecord.connection_pool : ActiveRecord::Base.connection_pool
+    end
 
     def build_task(task_name)
       Backfiller.log "Build #{task_name} task"


### PR DESCRIPTION
with last Rails 6 changes on multiple DB support, connection_pool can be closed and reopened, so we cannot rely on it on the initialization step