### PR TITLE
Ensure connections are release if an exception is raised

### DIFF
--- a/lib/backfiller/runner.rb
+++ b/lib/backfiller/runner.rb
@@ -46,12 +46,14 @@ module Backfiller
       master_connection = acquire_connection
       worker_connection = acquire_connection
 
-      run_cursor_loop(master_connection) do |row|
-        process_method.call(worker_connection, row)
+      begin
+        run_cursor_loop(master_connection) do |row|
+          process_method.call(worker_connection, row)
+        end
+      ensure
+        release_connection(master_connection)
+        release_connection(worker_connection)
       end
-
-      release_connection(master_connection)
-      release_connection(worker_connection)
     end
 
     private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ require 'active_record'
 
 require_relative 'support/logger_mock'
 
+# Configure rspec matchers
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 # Create logging
 ActiveSupport::LogSubscriber.colorize_logging = false
 

--- a/spec/support/logger_mock.rb
+++ b/spec/support/logger_mock.rb
@@ -22,6 +22,10 @@ class LoggerMock
     end
   end
 
+  def level
+    Logger::DEBUG
+  end
+
   def reset
     @messages.clear
   end


### PR DESCRIPTION
Currently if the backfill raises an exception, the master and worker DB connections are not released. This can lead to all the connection in the pool being busy and never released. This results in subsequent queries receiving this error:
```
ActiveRecord::ConnectionTimeoutError: could not obtain a connection from the pool 
within 5.000 seconds (waited 5.001 seconds); all pooled connections were in use
```
This has primarily been observed when running specs to test a backfill. This probably isn't a big issue when running the rake task as the process will be killed when an exception occurs, but it does still seem worth fixing.

---
I had to add a `level` method to `LoggerMock` as some newer version of ActiveRecord calls this method on the logger.
```
Failures:

  1) Backfiller::Cursor 
     Failure/Error: let(:connection) { ActiveRecord::Base.connection }
     
     NoMethodError:
       undefined method `level' for #<LoggerMock:0x00007fd2ff2b2648 @messages=[]>
     # ./spec/backfiller/cursor_spec.rb:5:in `block (2 levels) in <top (required)>'
     # ./spec/backfiller/cursor_spec.rb:4:in `block (2 levels) in <top (required)>'
     # ./spec/backfiller/cursor_spec.rb:20:in `block (2 levels) in <top (required)>'
```