### PR TITLE
Fix bug where cursor results could be cached

### DIFF
--- a/lib/backfiller/cursor/postgresql.rb
+++ b/lib/backfiller/cursor/postgresql.rb
@@ -35,7 +35,7 @@ module Backfiller
       end
 
       def fetch(count)
-        @connection.select_all "FETCH #{count} FROM #{@name}"
+        @connection.exec_query "FETCH #{count} FROM #{@name}"
       end
 
       def close

--- a/spec/backfiller/cursor_spec.rb
+++ b/spec/backfiller/cursor_spec.rb
@@ -21,32 +21,50 @@ RSpec.describe Backfiller::Cursor do
   end
 
   describe '#fetch' do
-    subject do
-      results = []
-      connection.transaction do
-        cursor.open
-        results << cursor.fetch(2)
-        results << cursor.fetch(2)
-        results << cursor.fetch(2)
-        cursor.close
+    shared_examples :fetches_results do
+      subject do
+        results = []
+        connection.transaction do
+          cursor.open
+          results << cursor.fetch(2)
+          results << cursor.fetch(2)
+          results << cursor.fetch(2)
+          cursor.close
+        end
+        results
       end
-      results
+
+      specify do
+        expect(subject.size).to eq(3)
+
+        expect(subject[0]).to be_instance_of(ActiveRecord::Result)
+        expect(subject[0].length).to eq(2)
+        expect(subject[0][0]).to eq('id' => 1, 'name' => 'Alice')
+        expect(subject[0][1]).to eq('id' => 2, 'name' => 'Bob')
+
+        expect(subject[1]).to be_instance_of(ActiveRecord::Result)
+        expect(subject[1].length).to eq(1)
+        expect(subject[1][0]).to eq('id' => 3, 'name' => 'Carlos')
+
+        expect(subject[2]).to be_instance_of(ActiveRecord::Result)
+        expect(subject[2].length).to eq(0)
+      end
     end
 
-    specify do
-      expect(subject.size).to eq(3)
+    context 'with query cache disabled' do
+      around do |ex|
+        ActiveRecord::Base.uncached { ex.run }
+      end
 
-      expect(subject[0]).to be_instance_of(ActiveRecord::Result)
-      expect(subject[0].length).to eq(2)
-      expect(subject[0][0]).to eq('id' => 1, 'name' => 'Alice')
-      expect(subject[0][1]).to eq('id' => 2, 'name' => 'Bob')
+      it_behaves_like :fetches_results
+    end
 
-      expect(subject[1]).to be_instance_of(ActiveRecord::Result)
-      expect(subject[1].length).to eq(1)
-      expect(subject[1][0]).to eq('id' => 3, 'name' => 'Carlos')
+    context 'with query cache enabled' do
+      around do |ex|
+        ActiveRecord::Base.cache { ex.run }
+      end
 
-      expect(subject[2]).to be_instance_of(ActiveRecord::Result)
-      expect(subject[2].length).to eq(0)
+      it_behaves_like :fetches_results
     end
   end
 end


### PR DESCRIPTION
The Active Record [connection.select_all()](https://github.com/rails/rails/blob/1f6cef4ca546b3a9f7aa12c0f10c7d1d1cfbab5a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L197-L214) method is intended to be used for `SELECT` statements. If query caching is enabled when a backfill is executed, this leads to Active Record returning the same result set each time the `FETCH ... FROM` query is executed. The end result is the backfill being stuck in an infinite loop. Switching to `.exec_query()` fixes this issue since Active Record does not apply caching to this method. These two methods have the same `ActiveRecord::Result` return type so there shouldn't be any backward compatibility issues.

Specs were updated to test with both query caching enabled and disabled. I'd suggest using the hide whitespace feature to get a cleaner diff.